### PR TITLE
Autocomplete's `buildSuggestionsFromResponse` returns an empty array …

### DIFF
--- a/src/us_autocomplete/Client.js
+++ b/src/us_autocomplete/Client.js
@@ -47,6 +47,8 @@ class Client {
 		}
 
 		function buildSuggestionsFromResponse(payload) {
+			if (payload.suggestions === null) return [];
+
 			return payload.suggestions.map(suggestion => new Suggestion(suggestion));
 		}
 	}

--- a/tests/us_autocomplete/test_Client.js
+++ b/tests/us_autocomplete/test_Client.js
@@ -75,6 +75,18 @@ describe("A US Autocomplete Client", function () {
 		return expect(client.send(lookup)).to.eventually.be.rejectedWith(expectedError);
 	});
 
+	it("returns an empty array when no suggestions are returned.", () => {
+		let mockExpectedPayload = {suggestions: null};
+		let mockSender = new MockSenderWithResponse(mockExpectedPayload);
+		let client = new Client(mockSender);
+		let lookup = new Lookup("Please let this be easy to test.");
+		let expectedSuggestion = [];
+
+		return client.send(lookup).then(response => {
+			expect(lookup.result).to.deep.equal(expectedSuggestion);
+		});
+	});
+
 	it("attaches suggestions from a response to a lookup.", function () {
 		const responseData = {
 			text: "a",


### PR DESCRIPTION
…when given a response payload when `suggestions` === `null`.