### PR TITLE
No longer uploading to s3 bucket on every publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ publish: clean test version upload unversion
 	git push origin --tags
 
 upload:
-	npm publish && node browserify.js && node s3.js
+	npm publish
+
+upload_s3:
+	node browserify.js && node s3.js
 
 version:
 	sed -i.bak -e 's/^ "version": "0\.0\.0",/ "version": "$(VERSION)",/g' "$(VERSION_FILE1)" && rm -f "$(VERSION_FILE1).bak"


### PR DESCRIPTION
Since we removed the link from the site a year ago, no one has attempted to access newer versions of the SDK via the s3 link.